### PR TITLE
feat: :sparkles: Upgraded npm package for npx usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the Javascript SDK for building Javascript applications ready for deploy
 - [FastEdge JS SDK](#fastedge-js-sdk)
   - [Table of Contents](#table-of-contents)
   - [Getting Started](#getting-started)
-  - [Usage](#usage)
+  - [Installation](#installation)
     - [Basic Javascript Example](#basic-javascript-example)
   - [How to compile](#how-to-compile)
     - [componentize-cli](#componentize-cli)
@@ -29,7 +29,7 @@ Please read through the documentation provided by Gcore.
 - Deploying an App:
   [Documentation](https://gcore.com/docs/fastedge/getting-started/create-fastedge-apps#stage-2-deploy-an-app)
 
-## Usage
+## Installation
 
 Required:
 
@@ -37,7 +37,7 @@ Required:
 
 Setup:
 
-- `npm install`
+- `npm install --save-dev @gcoredev/fastedge-sdk-js`
 
 ### Basic Javascript Example
 
@@ -61,7 +61,7 @@ There are two methods to build your own javascript into a runtime wasm.
 This is a command-line tool that allows you to provide the input js file and the output wasm file.
 
 ```sh
-node ./componentize-cli.js dist/index.js dist/main.wasm
+npx componentize-cli dist/index.js dist/main.wasm
 
 ```
 
@@ -69,12 +69,12 @@ This would take your `index.js` entrypoint file and compile it into a runtime `w
 loading on FastEdge Compute.
 
 Under the hood it uses [esbuild](https://esbuild.github.io/) to compile your `index.js` file before
-compiling into a wasm. This allows you to include multiple files into the /dist folder and import
-them as ESM modules.
+compiling it into a binary.wasm. This allows you to include multiple files into the /dist folder and
+import them as ES modules, `componentize-cli` will bundle them on your behalf.
 
 ### componentize
 
-This is a JS function provided by an NPM package, allowing you to build your runtime wasm within the
+This is a JS function provided by the NPM package allowing you to build your runtime.wasm within the
 context of a Javascript config file / project.
 
 ```js

--- a/componentize-cli.js
+++ b/componentize-cli.js
@@ -1,8 +1,11 @@
+#!/usr/bin/env node
+
 // src/componentize.js
 import { spawnSync as spawnSync2 } from "node:child_process";
 import { readFile as readFile2, writeFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-import { componentNew, preview1AdapterReactorPath } from "@bytecodealliance/jco";
+import path from "node:path";
+import { fileURLToPath as fileURLToPath2 } from "node:url";
+import { componentNew } from "@bytecodealliance/jco";
 import wizer from "@bytecodealliance/wizer";
 
 // src/get-js-input.js
@@ -50,10 +53,12 @@ async function getJsInputContents(jsInput, preBundleJSInput) {
 
 // src/inject-js-builtins.js
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 var PREAMBLE = ";{\n// Precompiled JS builtins\n";
 var POSTAMBLE = "}\n";
 var injectJSBuiltins = (contents) => {
-  const internals = readFileSync("./lib/js-builtins.js", "utf8");
+  const jsBuiltinsPath = fileURLToPath(new URL("./lib/js-builtins.js", import.meta.url));
+  const internals = readFileSync(jsBuiltinsPath, "utf8");
   return `${PREAMBLE}${internals}${POSTAMBLE}${contents}`;
 };
 
@@ -77,9 +82,9 @@ SyntaxError: Invalid or unexpected token
   );
   return true;
 }
-async function isFile(path, allowNonexistent = false) {
+async function isFile(path2, allowNonexistent = false) {
   try {
-    const stats = await stat(path);
+    const stats = await stat(path2);
     return stats.isFile();
   } catch (error) {
     if (error.code === "ENOENT") {
@@ -88,13 +93,13 @@ async function isFile(path, allowNonexistent = false) {
     throw error;
   }
 }
-async function createOutputDirectory(path) {
+async function createOutputDirectory(path2) {
   try {
-    await mkdir(dirname(path), {
+    await mkdir(dirname(path2), {
       recursive: true
     });
   } catch (error) {
-    console.error(`Error: Failed to create the "output" (${path}) directory`, error.message);
+    console.error(`Error: Failed to create the "output" (${path2}) directory`, error.message);
     process.exit(1);
   }
 }
@@ -173,13 +178,15 @@ function precompile(source, filename = "<input>") {
 async function componentize(jsInput, output, opts = {}) {
   const {
     debug = false,
-    wasmEngine = fileURLToPath(new URL("./lib/fastedge-runtime.wasm", import.meta.url)),
+    wasmEngine = fileURLToPath2(new URL("./lib/fastedge-runtime.wasm", import.meta.url)),
     enableStdout = false,
     enablePBL = false,
     preBundleJSInput = true
   } = opts;
-  const jsPath = fileURLToPath(new URL(jsInput, import.meta.url));
-  const wasmOutputDir = fileURLToPath(new URL(output, import.meta.url));
+  const jsPath = fileURLToPath2(new URL(path.resolve(process.cwd(), jsInput), import.meta.url));
+  const wasmOutputDir = fileURLToPath2(
+    new URL(path.resolve(process.cwd(), output), import.meta.url)
+  );
   await validateFilePaths(jsPath, wasmOutputDir, wasmEngine);
   const contents = await getJsInputContents(jsPath, preBundleJSInput);
   const application = precompile(injectJSBuiltins(contents));
@@ -219,7 +226,7 @@ async function componentize(jsInput, output, opts = {}) {
     process.exit(1);
   }
   const coreComponent = await readFile2(output);
-  const adapter = fileURLToPath(
+  const adapter = fileURLToPath2(
     new URL("./lib/wasi_snapshot_preview1.reactor.wasm", import.meta.url)
   );
   const generatedComponent = await componentNew(coreComponent, [

--- a/esbuild/componentize.js
+++ b/esbuild/componentize.js
@@ -1,4 +1,7 @@
 import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
 
 await build({
   entryPoints: ["./src/componentize.js", "./src/componentize-cli.js"],
@@ -16,3 +19,13 @@ await build({
     "acorn-walk",
   ],
 });
+
+const prependNodeShebangToFile = (relativeFilePath) => {
+  const filePath = fileURLToPath(
+    new URL(path.resolve(process.cwd(), relativeFilePath), import.meta.url),
+  );
+  const content = readFileSync(filePath, "utf8");
+  writeFileSync(filePath, "#!/usr/bin/env node\n\n" + content);
+};
+
+prependNodeShebangToFile("./componentize-cli.js");

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "type": "git",
     "url": "git+https://github.com/G-Core/FastEdge-sdk-js.git"
   },
+  "bin": {
+    "componentize-cli": "./componentize-cli.js"
+  },
   "files": [
     "types",
     "componentize.js",
     "componentize-cli.js",
-    "docs/",
     "lib/*.wasm",
     "lib/*.js",
     "README.md"


### PR DESCRIPTION
Allow users to run componentize-cli using npx without needing to install anything.

esbuild-shabang injection

esbuild-shabang injection