### PR TITLE
perf: :rocket: FastEdge project folder ES6 reqd files

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,1 +1,4 @@
-export const CONFIG_FILE_PATH = '.fastedge/build-config.js';
+const PROJECT_DIRECTORY = '.fastedge';
+const CONFIG_FILE_PATH = `${PROJECT_DIRECTORY}/build-config.js`;
+
+export { CONFIG_FILE_PATH, PROJECT_DIRECTORY };

--- a/src/fastedge-init/create-config.js
+++ b/src/fastedge-init/create-config.js
@@ -1,6 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 
-import { CONFIG_FILE_PATH } from '~constants/index.js';
+import { CONFIG_FILE_PATH, PROJECT_DIRECTORY } from '~constants/index.js';
 import { createOutputDirectory } from '~utils/file-system.js';
 
 /**
@@ -91,4 +91,30 @@ async function createConfigFile(type, buildConfig, serverConfig) {
   await writeFile(CONFIG_FILE_PATH, fileContents, 'utf-8');
 }
 
-export { createConfigFile };
+/**
+ * Creates basic package.json & jsconfig.json files for the ./fastedge folder
+ * This ensures when building FastEdge it is using ES6 modules
+ * i.e. end-user is building a project still based on ES5 / CommonJS
+ */
+async function createProjectFiles() {
+  await createOutputDirectory(PROJECT_DIRECTORY);
+
+  const packageJsonContents = [
+    '{',
+    '  "name": "fastedge-build",',
+    '  "version": "1.0.0",',
+    '  "description": "fastedge-build project folder uses ES6",',
+    '  "type": "module"',
+    '}',
+  ].join('\n');
+
+  await writeFile(`${PROJECT_DIRECTORY}/package.json`, packageJsonContents, 'utf-8');
+
+  const jsConfigContents = ['{', '  "compilerOptions": {', '    "target": "ES6"', '  }', '}'].join(
+    '\n',
+  );
+
+  await writeFile(`${PROJECT_DIRECTORY}/jsconfig.json`, jsConfigContents, 'utf-8');
+}
+
+export { createConfigFile, createProjectFiles };

--- a/src/fastedge-init/static-site.js
+++ b/src/fastedge-init/static-site.js
@@ -1,7 +1,7 @@
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { createConfigFile } from './create-config.js';
+import { createConfigFile, createProjectFiles } from './create-config.js';
 
 import { normalizePath } from '~utils/config-helpers.js';
 import { createOutputDirectory, isDirectory, isFile } from '~utils/file-system.js';
@@ -76,6 +76,8 @@ async function setupStaticApp() {
       );
     }
   }
+
+  await createProjectFiles(); // ES6 requirements: package.json & jsconfig.json etc..
 
   await createConfigFile(
     'static',


### PR DESCRIPTION
fastedge-init now creates package.json and jsconfig.json files to ensure we can still build projects that compile to commonjs/es5