### PR TITLE
fix: :adhesive_bandage: added Response.clone to the commented out types

### DIFF
--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -509,12 +509,13 @@ declare var Response: {
   json(data: any, init?: ResponseInit): Response;
 
   // ---------------------------------------------------------------------------
-  // Spec static methods not implemented by the StarlingMonkey runtime
+  // Spec methods not implemented by the StarlingMonkey runtime
   // ---------------------------------------------------------------------------
   // Will be uncommented when the runtime exposes them. See:
   //   runtime/StarlingMonkey/builtins/web/fetch/request-response.cpp
   //
-  // error(): Response;
+  // error(): Response;           // static
+  // prototype.clone(): Response; // instance
 };
 
 /**


### PR DESCRIPTION
Ensure global types displays Response.clone() even though it is commented out and not supported